### PR TITLE
Containerize the app into Docker using Python 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,42 @@ This application is designed to provide responses to any queries regarding ticke
     ```sh
     python monitoring/observability.py
     ```
+
+## Docker Setup Instructions
+
+### Building Docker Containers
+
+1. Build the backend Docker container:
+    ```sh
+    docker build -t backend ./backend
+    ```
+
+2. Build the frontend Docker container:
+    ```sh
+    docker build -t frontend ./frontend
+    ```
+
+### Running Docker Containers
+
+1. Run the backend Docker container:
+    ```sh
+    docker run -p 8000:8000 backend
+    ```
+
+2. Run the frontend Docker container:
+    ```sh
+    docker run -p 3000:3000 frontend
+    ```
+
+### Using Docker Compose
+
+1. Start all services using docker-compose:
+    ```sh
+    docker-compose up --build
+    ```
+
+2. Access the backend API at `http://localhost:8000`.
+
+3. Access the frontend application at `http://localhost:3000`.
+
+4. MongoDB will be running at `mongodb://localhost:27017`.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,14 @@
+# Use python:3.11-slim as the base image
+FROM python:3.11-slim
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the backend directory into the Docker image
+COPY backend /app
+
+# Install the required dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Set the entrypoint to run the FastAPI application using uvicorn
+ENTRYPOINT ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3.8'
+
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    container_name: backend
+    ports:
+      - "8000:8000"
+    networks:
+      - app-network
+
+  frontend:
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile
+    container_name: frontend
+    ports:
+      - "3000:3000"
+    networks:
+      - app-network
+
+  mongodb:
+    image: mongo:latest
+    container_name: mongodb
+    ports:
+      - "27017:27017"
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    driver: bridge

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,14 @@
+# Use node:14-alpine as the base image
+FROM node:14-alpine
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the frontend directory into the Docker image
+COPY . .
+
+# Install the required dependencies using npm
+RUN npm install
+
+# Set the entrypoint to run the Next.js application using npm run dev
+CMD ["npm", "run", "dev"]


### PR DESCRIPTION
Containerize the application into Docker using Python 3.11 and Node 14.

* **Backend Dockerfile**
  - Use `python:3.11-slim` as the base image.
  - Copy the `backend` directory into the Docker image.
  - Install the required dependencies using `pip`.
  - Set the entrypoint to run the FastAPI application using `uvicorn`.

* **Frontend Dockerfile**
  - Use `node:14-alpine` as the base image.
  - Copy the `frontend` directory into the Docker image.
  - Install the required dependencies using `npm`.
  - Set the entrypoint to run the Next.js application using `npm run dev`.

* **docker-compose.yml**
  - Define a service for the FastAPI backend.
  - Define a service for the Next.js frontend.
  - Define a service for MongoDB.
  - Set up network configuration for the services.

* **README.md**
  - Add instructions for building and running the Docker containers.
  - Update the setup instructions to include Docker.
  - Add a section for using `docker-compose` to start the services.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/anupmanekar/jira-rag-app/pull/1?shareId=d1b941a1-406c-4466-9b0c-a523ab2c7653).