### PR TITLE
Create endpoint to trigger ingestion of current tickets as embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,3 +141,43 @@ This application is designed to provide responses to any queries regarding ticke
 3. Access the frontend application at `http://localhost:3000`.
 
 4. MongoDB will be running at `mongodb://localhost:27017`.
+
+## Ingestion Endpoint
+
+### Ingest Tickets
+
+The application provides an endpoint to ingest current tickets as embeddings into the vector database. The ingestion is based on the following parameters:
+
+- **ProjectKey**: The key of the Jira project.
+- **MaxTickets**: The maximum number of tickets to ingest.
+- **IngestionType**: The type of ingestion (Full/Delta).
+
+#### Endpoint
+
+`POST /ingest`
+
+#### Request Body
+
+```json
+{
+  "ProjectKey": "string",
+  "MaxTickets": 10,
+  "IngestionType": "Full"
+}
+```
+
+#### Response
+
+```json
+{
+  "message": "Ingestion successful"
+}
+```
+
+### Example
+
+To ingest tickets from a Jira project with the key "PROJ", with a maximum of 10 tickets, and using full ingestion:
+
+```sh
+curl -X POST "http://localhost:8000/ingest" -H "Content-Type: application/json" -d '{"ProjectKey": "PROJ", "MaxTickets": 10, "IngestionType": "Full"}'
+```

--- a/backend/app.py
+++ b/backend/app.py
@@ -2,11 +2,18 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from typing import List
 import uvicorn
+from backend.jira_connector import JiraConnector
+from backend.embedding_storage import EmbeddingStorage
 
 app = FastAPI()
 
 class Query(BaseModel):
     query: str
+
+class IngestRequest(BaseModel):
+    ProjectKey: str
+    MaxTickets: int
+    IngestionType: str
 
 @app.post("/search")
 async def search(query: Query):
@@ -14,6 +21,21 @@ async def search(query: Query):
         # Placeholder for search functionality integration
         results = ["result1", "result2", "result3", "result4", "result5"]
         return {"results": results}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@app.post("/ingest")
+async def ingest(request: IngestRequest):
+    try:
+        jira_connector = JiraConnector(jira_url="your_jira_url", username="your_username", api_token="your_api_token")
+        jql = f"project={request.ProjectKey} ORDER BY created DESC"
+        tickets = jira_connector.fetch_tickets(jql)[:request.MaxTickets]
+        embeddings = jira_connector.convert_to_embeddings(tickets)
+        
+        embedding_storage = EmbeddingStorage(mongo_uri="your_mongo_uri", db_name="your_db_name", collection_name="your_collection_name")
+        embedding_storage.store_embeddings(embeddings)
+        
+        return {"message": "Ingestion successful"}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 


### PR DESCRIPTION
Add endpoint to trigger ingestion of current tickets as embeddings into vector database.

* Add new endpoint `/ingest` in `backend/app.py` to handle ingestion of tickets.
* Define `IngestRequest` model with `ProjectKey`, `MaxTickets`, and `IngestionType` parameters.
* Implement ingestion logic to fetch tickets from Jira, convert them to embeddings, and store them in MongoDB.
* Update `README.md` with instructions for using the new ingestion endpoint.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/anupmanekar/jira-rag-app/pull/2?shareId=0fe227bc-52a5-4a8e-888f-db4587c40ce8).