### PR TITLE
Generate a swagger documentation for supported APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,3 +181,13 @@ To ingest tickets from a Jira project with the key "PROJ", with a maximum of 10 
 ```sh
 curl -X POST "http://localhost:8000/ingest" -H "Content-Type: application/json" -d '{"ProjectKey": "PROJ", "MaxTickets": 10, "IngestionType": "Full"}'
 ```
+
+## Swagger Documentation
+
+The application provides Swagger documentation for the supported APIs. You can access the Swagger UI at the following URL:
+
+```
+http://localhost:8000/docs
+```
+
+This documentation provides a user-friendly interface to explore and test the available API endpoints.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,5 +13,8 @@ COPY .env /app/.env
 # Install the required dependencies
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Add fastapi to the list of dependencies
+RUN echo "fastapi" >> requirements.txt
+
 # Set the entrypoint to run the FastAPI application using uvicorn
 ENTRYPOINT ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app.py
+++ b/backend/app.py
@@ -6,6 +6,7 @@ import uvicorn
 from backend.jira_connector import JiraConnector
 from backend.embedding_storage import EmbeddingStorage
 from dotenv import load_dotenv
+from fastapi.openapi.utils import get_openapi
 
 load_dotenv()
 
@@ -50,6 +51,20 @@ async def ingest(request: IngestRequest):
         return {"message": "Ingestion successful"}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+def custom_openapi():
+    if app.openapi_schema:
+        return app.openapi_schema
+    openapi_schema = get_openapi(
+        title="Jira RAG App",
+        version="1.0.0",
+        description="API documentation for the Jira RAG App",
+        routes=app.routes,
+    )
+    app.openapi_schema = openapi_schema
+    return app.openapi_schema
+
+app.openapi = custom_openapi
 
 if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
Add Swagger documentation for supported APIs.

* **backend/app.py**
  - Import `get_openapi` from `fastapi.openapi.utils`.
  - Add `custom_openapi` function to generate the OpenAPI schema.
  - Set `app.openapi` to `custom_openapi` to use the custom OpenAPI schema.

* **backend/Dockerfile**
  - Add `fastapi` to the list of dependencies in `requirements.txt`.

* **README.md**
  - Add a section on how to access the Swagger documentation.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/anupmanekar/jira-rag-app?shareId=XXXX-XXXX-XXXX-XXXX).