### PR TITLE
Add CORS middleware to FastAPI application

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -11,12 +11,21 @@ from backend.rag_handler import RAGHandler
 from dotenv import load_dotenv
 from fastapi.openapi.utils import get_openapi
 from monitoring.observability import getLogger
+from fastapi.middleware.cors import CORSMiddleware
 
 logger = getLogger(__name__)
 
 load_dotenv()
 
 app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 azure_connector = AzureDevOpsConnector.get_instance(
             azure_devops_url=os.environ.get("AZURE_DEVOPS_URL"),

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,3 +10,4 @@ requests
 azure-core
 azure-devops
 msrest
+fastapi-cors


### PR DESCRIPTION
Add CORS middleware to FastAPI application to handle cross-origin requests.

* Import `CORSMiddleware` from `fastapi.middleware.cors` in `backend/app.py`.
* Add CORS middleware to the FastAPI application in `backend/app.py` with settings to allow all origins, credentials, methods, and headers.
* Add `fastapi-cors` to the list of dependencies in `backend/requirements.txt`.

